### PR TITLE
Alternative method for skipping npm install, fixes #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ npx netlify-plugin-pnpm-preinstaller
      package = "./plugins/pnpm-preinstaller"
 ```
 
-3. Point `npm` to `/dev/null`
+3. Prevent redundant `npm` install
 ```
 [build.environment]
-        NPM_FLAGS="--prefix=/dev/null"
+        NPM_FLAGS="--version"
 ```
 
 4. Done!


### PR DESCRIPTION
Also adjusted (3) description to make clear why we're doing this (I saw an earlier issue where the user was confused about the `--prefix` hack).